### PR TITLE
chore(docs): normalise code-block indentation from tabs to 4 spaces

### DIFF
--- a/docs/Ajax_Model.md
+++ b/docs/Ajax_Model.md
@@ -89,14 +89,14 @@ class Some_Ajax extends Ajax {
     protected bool $logged_out;
 
     /**
-	 * @param \Psr\Http\Message\ServerRequestInterface $request
-	 * @param \PinkCrab\Ajax\Dispatcher\Response_Factory $response_factory
-	 * @return \Psr\Http\Message\ResponseInterface
-	 */
-	public function callback(
-		ServerRequestInterface $request,
-		Response_Factory $response_factory
-	): ResponseInterface {
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \PinkCrab\Ajax\Dispatcher\Response_Factory $response_factory
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function callback(
+        ServerRequestInterface $request,
+        Response_Factory $response_factory
+    ): ResponseInterface {
         // Return something 
         return $response_factory->success( 'something' );
     }


### PR DESCRIPTION
Tabs in fenced markdown code blocks render at the browser default 8-column tab-stop on the docs site, making nested code look inconsistently spaced next to other blocks that use 4-space indents. Source PHP files keep tabs (project/WP convention) — this is a docs-only normalisation.

git diff -w shows zero changes (no semantic edits).